### PR TITLE
feat: implement custom window titlebar for non mac systems

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -58,6 +58,9 @@ importers:
       '@tauri-apps/plugin-opener':
         specifier: ^2
         version: 2.4.0
+      '@tauri-apps/plugin-os':
+        specifier: ~2
+        version: 2.3.0
       '@tiptap/extension-character-count':
         specifier: ^3.0.7
         version: 3.0.7(@tiptap/extensions@3.0.7(@tiptap/core@3.0.7(@tiptap/pm@3.0.7))(@tiptap/pm@3.0.7))
@@ -1690,6 +1693,9 @@ packages:
 
   '@tauri-apps/plugin-opener@2.4.0':
     resolution: {integrity: sha512-43VyN8JJtvKWJY72WI/KNZszTpDpzHULFxQs0CJBIYUdCRowQ6Q1feWTDb979N7nldqSuDOaBupZ6wz2nvuWwQ==}
+
+  '@tauri-apps/plugin-os@2.3.0':
+    resolution: {integrity: sha512-dm3bDsMuUngpIQdJ1jaMkMfyQpHyDcaTIKTFaAMHoKeUd+Is3UHO2uzhElr6ZZkfytIIyQtSVnCWdW2Kc58f3g==}
 
   '@testing-library/dom@10.4.0':
     resolution: {integrity: sha512-pemlzrSESWbdAloYml3bAJMEfNh1Z7EduzqPKprCH5S341frlpYnUEW0H72dLxa6IsYr+mPno20GiSm+h9dEdQ==}
@@ -4638,6 +4644,10 @@ snapshots:
       '@tauri-apps/api': 2.6.0
 
   '@tauri-apps/plugin-opener@2.4.0':
+    dependencies:
+      '@tauri-apps/api': 2.6.0
+
+  '@tauri-apps/plugin-os@2.3.0':
     dependencies:
       '@tauri-apps/api': 2.6.0
 

--- a/src-tauri/capabilities/window.json
+++ b/src-tauri/capabilities/window.json
@@ -11,9 +11,6 @@
     "core:event:allow-unlisten",
     "core:window:allow-close",
     "core:window:allow-minimize",
-    "core:window:allow-maximize",
-    "core:window:allow-unmaximize",
-    "core:window:allow-toggle-maximize",
     "core:window:allow-start-dragging",
     "core:window:allow-set-position"
   ]

--- a/src-tauri/capabilities/window.json
+++ b/src-tauri/capabilities/window.json
@@ -11,6 +11,8 @@
     "core:event:allow-unlisten",
     "core:window:allow-close",
     "core:window:allow-minimize",
+    "core:window:allow-maximize",
+    "core:window:allow-unmaximize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-start-dragging",
     "core:window:allow-set-position"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -136,14 +136,12 @@ pub fn custom_colored_format(
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     #[cfg(debug_assertions)]
-    let log_spec = LogSpecification::builder()
-        .module("notes", log::LevelFilter::Trace)
-        .build();
+    let log_spec =
+        LogSpecification::builder().default(log::LevelFilter::Trace).build();
 
     #[cfg(not(debug_assertions))]
-    let log_spec = LogSpecification::builder()
-        .module("notes", log::LevelFilter::Info)
-        .build();
+    let log_spec =
+        LogSpecification::builder().default(log::LevelFilter::Info).build();
 
     let log_dir = std::env::temp_dir().join("notes_logs");
     std::fs::create_dir_all(&log_dir).unwrap_or_else(|e| {
@@ -173,6 +171,7 @@ pub fn run() {
 
     #[allow(unused_mut)]
     let mut builder = tauri::Builder::default()
+        .plugin(tauri_plugin_os::init())
         .plugin(
             tauri_plugin_window_state::Builder::new()
                 .skip_initial_state(&format!("{MAIN_WINDOW_PREFIX}0"))

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -87,6 +87,12 @@ pub(crate) fn create_window<R: Runtime>(
                 .hidden_title(true)
                 .title_bar_style(TitleBarStyle::Overlay);
         }
+
+        #[cfg(not(target_os = "macos"))]
+        {
+            debug_log!("Disabling titlebar");
+            win_builder = win_builder.decorations(false);
+        }
     }
 
     if let Some((max_width, max_height)) = config.max_size {

--- a/src-web/package.json
+++ b/src-web/package.json
@@ -20,6 +20,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-dialog": "^2.3.1",
     "@tauri-apps/plugin-opener": "^2",
+    "@tauri-apps/plugin-os": "~2",
     "@tiptap/extension-character-count": "^3.0.7",
     "@tiptap/extension-code-block": "^3.0.7",
     "@tiptap/extension-list": "^3.0.7",

--- a/src-web/src/components/header.tsx
+++ b/src-web/src/components/header.tsx
@@ -66,7 +66,11 @@ export const Header = forwardRef<
       <div
         className="flex h-full items-center justify-between"
         id={HEADER_ID}
-        {...(!isMac ? { 'data-tauri-drag-region': '' } : {})}
+        onMouseDown={(e) => {
+          e.stopPropagation();
+          e.preventDefault();
+          currentWindow.startDragging();
+        }}
         onDoubleClick={onDoubleClick}
       >
         <div className="flex items-center pl-2">

--- a/src-web/src/components/header.tsx
+++ b/src-web/src/components/header.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon } from 'lucide-react';
-import { forwardRef, useEffect, useState } from 'react';
+import { forwardRef } from 'react';
 import { cn } from '~/lib/classname';
 import { BrowseDialog, type BrowseDialogProps } from './browse-dialog';
 import { Button } from './ui/button';
@@ -65,8 +65,8 @@ export const Header = forwardRef<
     >
       <div
         className="flex h-full items-center justify-between"
-        data-tauri-drag-region
         id={HEADER_ID}
+        {...(!isMac ? { 'data-tauri-drag-region': '' } : {})}
         onDoubleClick={onDoubleClick}
       >
         <div className="flex items-center pl-2">
@@ -84,78 +84,8 @@ export const Header = forwardRef<
 Header.displayName = 'Header';
 
 function WindowControls() {
-  const [maximized, setMaximized] = useState(false);
-
-  useEffect(() => {
-    currentWindow.isMaximized().then(setMaximized);
-    const win = currentWindow;
-    const handler = () => win.isMaximized().then(setMaximized);
-    let unlisten: (() => void) | undefined;
-    win.onResized(handler).then((fn) => {
-      unlisten = fn;
-    });
-    return () => {
-      if (unlisten) unlisten();
-    };
-  }, []);
-
   return (
     <div className="flex h-full select-none items-center">
-      <button
-        className="flex h-12 w-12 items-center justify-center rounded-none text-gray-500 transition hover:bg-gray-100 active:bg-gray-200"
-        onClick={() => currentWindow.minimize()}
-        aria-label="Minimize"
-        tabIndex={0}
-      >
-        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-          <rect
-            x="3"
-            y="8"
-            width="10"
-            height="1.5"
-            rx="0.75"
-            fill="currentColor"
-          />
-        </svg>
-      </button>
-      <button
-        className="flex h-12 w-12 items-center justify-center rounded-none text-gray-500 transition hover:bg-gray-100 active:bg-gray-200"
-        onClick={async () => {
-          const win = currentWindow;
-          const isMax = await win.isMaximized();
-          if (isMax) {
-            await win.unmaximize();
-            setMaximized(false);
-          } else {
-            await win.maximize();
-            setMaximized(true);
-          }
-        }}
-        aria-label="Maximize"
-        tabIndex={0}
-      >
-        {maximized ? (
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <g fill="none" stroke="currentColor" strokeWidth="1.5">
-              <rect x="4.5" y="4.5" width="7" height="7" rx="1.5" />
-              <rect x="6.5" y="6.5" width="5" height="5" rx="1" />
-            </g>
-          </svg>
-        ) : (
-          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
-            <rect
-              x="3.5"
-              y="3.5"
-              width="9"
-              height="9"
-              rx="2"
-              stroke="currentColor"
-              strokeWidth="1.5"
-              fill="none"
-            />
-          </svg>
-        )}
-      </button>
       <button
         className="flex h-12 w-12 items-center justify-center rounded-none text-gray-500 transition hover:bg-red-100 hover:text-red-600 focus:outline-none active:bg-red-200"
         onClick={() => currentWindow.close()}

--- a/src-web/src/components/header.tsx
+++ b/src-web/src/components/header.tsx
@@ -1,13 +1,15 @@
-import { getCurrentWindow } from '@tauri-apps/api/window';
 import { PlusIcon } from 'lucide-react';
-import { forwardRef } from 'react';
+import { forwardRef, useEffect, useState } from 'react';
 import { cn } from '~/lib/classname';
 import { BrowseDialog, type BrowseDialogProps } from './browse-dialog';
 import { Button } from './ui/button';
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
+import { platform } from '@tauri-apps/plugin-os';
 
 export const HEADER_ID = 'main-header';
 
-const currentWindow = getCurrentWindow();
+const currentWindow = getCurrentWebviewWindow();
+const isMac = platform() === 'macos';
 
 type HeaderProps = {
   activeNoteId?: string;
@@ -30,6 +32,28 @@ export const Header = forwardRef<
     ...rest
   } = props;
 
+  const ButtonGroup = () => (
+    <div className="pointer-events-auto flex items-center gap-2">
+      <BrowseDialog
+        activeNoteId={activeNoteId}
+        onNoteClick={onNoteClick}
+        onOpenChange={onOpenChange}
+        onNoteDelete={onNoteDelete}
+      />
+      <Button
+        onClick={(e) => {
+          e.stopPropagation();
+          onNewWindow();
+        }}
+        variant="ghost"
+        size="icon"
+        className="size-7 shrink-0 text-zinc-300 transition-colors duration-150 hover:text-zinc-600"
+      >
+        <PlusIcon className="h-4 w-4" />
+      </Button>
+    </div>
+  );
+
   return (
     <header
       {...rest}
@@ -40,39 +64,17 @@ export const Header = forwardRef<
       )}
     >
       <div
-        className="flex h-full items-center justify-between pr-1"
-        onMouseDown={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          currentWindow.startDragging();
-        }}
+        className="flex h-full items-center justify-between"
+        data-tauri-drag-region
         id={HEADER_ID}
         onDoubleClick={onDoubleClick}
       >
-        <div className="pointer-events-none flex items-center gap-2 pl-3.5">
-          <TrafficButton />
-          <TrafficButton />
-          <TrafficButton />
+        <div className="flex items-center pl-2">
+          {isMac ? <div className="w-[70px]" /> : <ButtonGroup />}
         </div>
 
-        <div className="flex items-center gap-2">
-          <BrowseDialog
-            activeNoteId={activeNoteId}
-            onNoteClick={onNoteClick}
-            onOpenChange={onOpenChange}
-            onNoteDelete={onNoteDelete}
-          />
-          <Button
-            onClick={(e) => {
-              e.stopPropagation();
-              onNewWindow();
-            }}
-            variant="ghost"
-            size="icon"
-            className="size-7 shrink-0 text-zinc-300 transition-colors duration-150 hover:text-zinc-600"
-          >
-            <PlusIcon className="h-4 w-4" />
-          </Button>
+        <div className="flex items-center">
+          {isMac ? <ButtonGroup /> : <WindowControls />}
         </div>
       </div>
     </header>
@@ -81,8 +83,100 @@ export const Header = forwardRef<
 
 Header.displayName = 'Header';
 
-type TrafficButtonProps = {};
+function WindowControls() {
+  const [maximized, setMaximized] = useState(false);
 
-function TrafficButton(_: TrafficButtonProps) {
-  return <div className="h-3 w-3 rounded-full bg-gray-300" />;
+  useEffect(() => {
+    currentWindow.isMaximized().then(setMaximized);
+    const win = currentWindow;
+    const handler = () => win.isMaximized().then(setMaximized);
+    let unlisten: (() => void) | undefined;
+    win.onResized(handler).then((fn) => {
+      unlisten = fn;
+    });
+    return () => {
+      if (unlisten) unlisten();
+    };
+  }, []);
+
+  return (
+    <div className="flex h-full select-none items-center">
+      <button
+        className="flex h-12 w-12 items-center justify-center rounded-none text-gray-500 transition hover:bg-gray-100 active:bg-gray-200"
+        onClick={() => currentWindow.minimize()}
+        aria-label="Minimize"
+        tabIndex={0}
+      >
+        <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+          <rect
+            x="3"
+            y="8"
+            width="10"
+            height="1.5"
+            rx="0.75"
+            fill="currentColor"
+          />
+        </svg>
+      </button>
+      <button
+        className="flex h-12 w-12 items-center justify-center rounded-none text-gray-500 transition hover:bg-gray-100 active:bg-gray-200"
+        onClick={async () => {
+          const win = currentWindow;
+          const isMax = await win.isMaximized();
+          if (isMax) {
+            await win.unmaximize();
+            setMaximized(false);
+          } else {
+            await win.maximize();
+            setMaximized(true);
+          }
+        }}
+        aria-label="Maximize"
+        tabIndex={0}
+      >
+        {maximized ? (
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <g fill="none" stroke="currentColor" strokeWidth="1.5">
+              <rect x="4.5" y="4.5" width="7" height="7" rx="1.5" />
+              <rect x="6.5" y="6.5" width="5" height="5" rx="1" />
+            </g>
+          </svg>
+        ) : (
+          <svg width="16" height="16" viewBox="0 0 16 16" fill="none">
+            <rect
+              x="3.5"
+              y="3.5"
+              width="9"
+              height="9"
+              rx="2"
+              stroke="currentColor"
+              strokeWidth="1.5"
+              fill="none"
+            />
+          </svg>
+        )}
+      </button>
+      <button
+        className="flex h-12 w-12 items-center justify-center rounded-none text-gray-500 transition hover:bg-red-100 hover:text-red-600 focus:outline-none active:bg-red-200"
+        onClick={() => currentWindow.close()}
+        aria-label="Close"
+        tabIndex={0}
+      >
+        <svg
+          width="16"
+          height="16"
+          viewBox="0 0 16 16"
+          fill="none"
+          className="m-0 block p-0"
+        >
+          <path
+            d="M5 5l6 6M11 5l-6 6"
+            stroke="currentColor"
+            strokeWidth="1.5"
+            strokeLinecap="round"
+          />
+        </svg>
+      </button>
+    </div>
+  );
 }

--- a/src-web/src/components/skeleton-editor.tsx
+++ b/src-web/src/components/skeleton-editor.tsx
@@ -2,6 +2,7 @@ import type { Note } from '@sticky/models';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { useNavigate } from '@tanstack/react-router';
 import { invoke } from '@tauri-apps/api/core';
+import { getCurrentWebviewWindow } from '@tauri-apps/api/webviewWindow';
 import {
   currentMonitor,
   getCurrentWindow,
@@ -283,9 +284,12 @@ export function SkeletonEditor(props: SkeletonEditorProps) {
     });
 
     queryClient.invalidateQueries(listNotesOptions());
-    await invoke('cmd_new_main_window', {
+    await invoke('cmd_new_child_window', {
+      parentWindow: getCurrentWebviewWindow(),
       url: `/${newNote.id}`,
-      size: [DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT],
+      label: `child_${newNote.id}`,
+      title: `Sticky`,
+      innerSize: [DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT],
     });
   }, [editor]);
 

--- a/src-web/src/components/skeleton-editor.tsx
+++ b/src-web/src/components/skeleton-editor.tsx
@@ -284,12 +284,9 @@ export function SkeletonEditor(props: SkeletonEditorProps) {
     });
 
     queryClient.invalidateQueries(listNotesOptions());
-    await invoke('cmd_new_child_window', {
-      parentWindow: getCurrentWebviewWindow(),
+    await invoke('cmd_new_main_window', {
       url: `/${newNote.id}`,
-      label: `child_${newNote.id}`,
-      title: `Sticky`,
-      innerSize: [DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT],
+      size: [DEFAULT_WINDOW_WIDTH, DEFAULT_WINDOW_HEIGHT],
     });
   }, [editor]);
 


### PR DESCRIPTION
This PR also contains a few small fixes/changes
- `logging` was not working so that was resolved too
- Replace the usage of `cmd_new_main_window` with `cmd_new_child_window`

<img width="696" height="433" alt="preview" src="https://github.com/user-attachments/assets/d2a81c8a-1275-4143-b503-48105a849521" />
