### PR TITLE
Find bar in footer, editor and window polish

### DIFF
--- a/src-tauri/src/mac_window.rs
+++ b/src-tauri/src/mac_window.rs
@@ -151,12 +151,45 @@ fn fade_traffic_lights(ns_window: cocoa::base::id, alpha: f64) {
     }
 }
 
+// The close button's fill at rest: system red while the window is key,
+// otherwise the appearance-aware dimmed grey.
+fn close_resting_color(ns_window: cocoa::base::id) -> (f64, f64, f64) {
+    use cocoa::base::{BOOL, YES};
+    let is_key: BOOL = unsafe { msg_send![ns_window, isKeyWindow] };
+    if is_key == YES {
+        CLOSE_RED
+    } else if is_dark_appearance(ns_window) {
+        DIMMED_GREY_DARK
+    } else {
+        DIMMED_GREY
+    }
+}
+
+// Repaints a traffic light circle's layer background.
+fn set_traffic_light_color(button: cocoa::base::id, rgb: (f64, f64, f64)) {
+    let (r, g, b) = rgb;
+    unsafe {
+        let color: cocoa::base::id = msg_send![
+            class!(NSColor),
+            colorWithSRGBRed: r green: g blue: b alpha: 1.0f64
+        ];
+        let cg_color: cocoa::base::id = msg_send![color, CGColor];
+        let layer: cocoa::base::id = msg_send![button, layer];
+        let _: () = msg_send![layer, setBackgroundColor: cg_color];
+    }
+}
+
 extern "C" fn traffic_light_mouse_entered(
     this: &objc::runtime::Object,
     _cmd: objc::runtime::Sel,
     _event: cocoa::base::id,
 ) {
     set_traffic_light_glyphs_hidden(this, false);
+    // `this` is the close button (it owns the cluster tracking area).
+    // Give it its red even while the window is unfocused, so hovering
+    // reveals the color the way native macOS does.
+    let close = this as *const objc::runtime::Object as cocoa::base::id;
+    set_traffic_light_color(close, CLOSE_RED);
 }
 
 extern "C" fn traffic_light_mouse_exited(
@@ -165,6 +198,9 @@ extern "C" fn traffic_light_mouse_exited(
     _event: cocoa::base::id,
 ) {
     set_traffic_light_glyphs_hidden(this, true);
+    let close = this as *const objc::runtime::Object as cocoa::base::id;
+    let ns_window: cocoa::base::id = unsafe { msg_send![close, window] };
+    set_traffic_light_color(close, close_resting_color(ns_window));
 }
 
 // NSButton subclass that reveals the cluster's glyph sublayers on hover,

--- a/src-tauri/src/window/command.rs
+++ b/src-tauri/src/window/command.rs
@@ -2,15 +2,11 @@
 
 use sticky_models::constants::COMMAND_WINDOW_HEIGHT;
 
-use super::panel::attach_panel_lifecycle;
+use super::panel::{attach_panel_lifecycle, PANEL_INSET, PANEL_TOP_OFFSET};
 use super::*;
 
 pub const COMMAND_WINDOW_MIN_WIDTH: f64 = 340.0;
 pub const COMMAND_WINDOW_MAX_WIDTH: f64 = 420.0;
-/// Horizontal inset from the parent window's edges.
-pub const COMMAND_WINDOW_INSET: f64 = 16.0;
-/// Distance between the parent's top edge and the panel's.
-pub const COMMAND_WINDOW_TOP_OFFSET: f64 = 50.0;
 
 /// Returns the label of the command palette attached to `parent_label`.
 pub fn command_window_label(parent_label: &str) -> String {
@@ -32,7 +28,7 @@ pub fn create_command_window(
     let parent_size =
         parent_window.outer_size().unwrap().to_logical::<f64>(scale_factor);
 
-    let width = (parent_size.width - COMMAND_WINDOW_INSET * 2.0)
+    let width = (parent_size.width - PANEL_INSET * 2.0)
         .clamp(COMMAND_WINDOW_MIN_WIDTH, COMMAND_WINDOW_MAX_WIDTH);
 
     let config = CreateWindowConfig {
@@ -69,7 +65,7 @@ pub fn create_command_window(
                 crate::mac_window::anchor_panel_to_parent(
                     &panel,
                     &parent,
-                    COMMAND_WINDOW_TOP_OFFSET,
+                    PANEL_TOP_OFFSET,
                 );
             })
             .expect("Failed to set up the command palette on the main thread");
@@ -120,7 +116,7 @@ pub fn present_command_window(
                 crate::mac_window::anchor_panel_to_parent(
                     &panel,
                     &parent,
-                    COMMAND_WINDOW_TOP_OFFSET,
+                    PANEL_TOP_OFFSET,
                 );
                 let _ = panel.show();
                 let _ = panel.set_focus();

--- a/src-tauri/src/window/panel.rs
+++ b/src-tauri/src/window/panel.rs
@@ -2,6 +2,15 @@
 
 use super::*;
 
+/// Distance between a parent window's top edge and a panel dropped
+/// below it. Shared so the search and command panels drop from the
+/// same spot.
+pub const PANEL_TOP_OFFSET: f64 = 69.5;
+
+/// Horizontal inset from the parent window's edges. Shared so both
+/// panels are the same width relative to their parent.
+pub const PANEL_INSET: f64 = 16.0;
+
 /// Grace period after a panel was hidden by losing focus.
 ///
 /// Clicking the toggle button while a panel is open blurs the panel

--- a/src-tauri/src/window/search.rs
+++ b/src-tauri/src/window/search.rs
@@ -2,15 +2,11 @@
 
 use sticky_models::constants::SEARCH_WINDOW_HEIGHT;
 
-use super::panel::attach_panel_lifecycle;
+use super::panel::{attach_panel_lifecycle, PANEL_INSET, PANEL_TOP_OFFSET};
 use super::*;
 
 pub const SEARCH_WINDOW_MIN_WIDTH: f64 = 360.0;
 pub const SEARCH_WINDOW_MAX_WIDTH: f64 = 480.0;
-/// Horizontal inset from the parent window's edges.
-pub const SEARCH_WINDOW_INSET: f64 = 16.0;
-/// Distance between the parent's top edge and the panel's.
-pub const SEARCH_WINDOW_TOP_OFFSET: f64 = 50.0;
 
 /// Returns the label of the search panel attached to `parent_label`.
 pub fn search_window_label(parent_label: &str) -> String {
@@ -32,7 +28,7 @@ pub fn create_search_window(
     let parent_size =
         parent_window.outer_size().unwrap().to_logical::<f64>(scale_factor);
 
-    let width = (parent_size.width - SEARCH_WINDOW_INSET * 2.0)
+    let width = (parent_size.width - PANEL_INSET * 2.0)
         .clamp(SEARCH_WINDOW_MIN_WIDTH, SEARCH_WINDOW_MAX_WIDTH);
 
     let config = CreateWindowConfig {
@@ -69,7 +65,7 @@ pub fn create_search_window(
                 crate::mac_window::anchor_panel_to_parent(
                     &panel,
                     &parent,
-                    SEARCH_WINDOW_TOP_OFFSET,
+                    PANEL_TOP_OFFSET,
                 );
             })
             .expect("Failed to set up the search panel on the main thread");
@@ -121,7 +117,7 @@ pub fn present_search_window(
                 crate::mac_window::anchor_panel_to_parent(
                     &panel,
                     &parent,
-                    SEARCH_WINDOW_TOP_OFFSET,
+                    PANEL_TOP_OFFSET,
                 );
                 let _ = panel.show();
                 let _ = panel.set_focus();

--- a/src-web/src/components/find-bar.tsx
+++ b/src-web/src/components/find-bar.tsx
@@ -1,5 +1,10 @@
 import { useEditorState, type Editor } from '@tiptap/react';
-import { ChevronDownIcon, ChevronUpIcon, XIcon } from 'lucide-react';
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  SearchIcon,
+  XIcon,
+} from 'lucide-react';
 import { useCallback, useEffect, useRef } from 'react';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
@@ -112,22 +117,26 @@ export function FindBar(props: FindBarProps) {
   };
 
   return (
-    <div className="border-border bg-background fixed right-2 top-[calc(var(--window-menu-height)+2px)] z-50 flex w-[calc(100%-1rem)] max-w-80 items-center gap-1 rounded-lg border p-1 shadow-md">
-      <Input
-        ref={inputRef}
-        value={query}
-        placeholder="Find in note..."
-        className="h-7 grow rounded-md border-none px-2 text-sm focus:border-none"
-        spellCheck={false}
-        autoComplete="off"
-        autoCorrect="off"
-        autoCapitalize="off"
-        onChange={(e) => {
-          editor.commands.setFindQuery(e.target.value);
-          scrollToActiveMatch(editor);
-        }}
-        onKeyDown={onInputKeyDown}
-      />
+    <div className="border-border h-9.5 flex shrink-0 items-center gap-1 border-t pr-3">
+      <label className="flex h-full grow items-center gap-2 pl-[var(--editor-inset-x)]">
+        <SearchIcon className="text-faint size-3.5 shrink-0" />
+
+        <Input
+          ref={inputRef}
+          value={query}
+          placeholder="Find in note…"
+          className="h-full grow rounded-none border-none bg-transparent p-0 text-sm focus:border-none"
+          spellCheck={false}
+          autoComplete="off"
+          autoCorrect="off"
+          autoCapitalize="off"
+          onChange={(e) => {
+            editor.commands.setFindQuery(e.target.value);
+            scrollToActiveMatch(editor);
+          }}
+          onKeyDown={onInputKeyDown}
+        />
+      </label>
 
       {query && (
         <Text
@@ -137,6 +146,8 @@ export function FindBar(props: FindBarProps) {
           {matchCount === 0 ? '0/0' : `${activeIndex + 1}/${matchCount}`}
         </Text>
       )}
+
+      <span className="bg-border mx-0.5 h-4 w-px shrink-0" />
 
       <Button
         size="icon"

--- a/src-web/src/components/find-bar.tsx
+++ b/src-web/src/components/find-bar.tsx
@@ -1,3 +1,4 @@
+import { useHotkey } from '@tanstack/react-hotkeys';
 import { useEditorState, type Editor } from '@tiptap/react';
 import {
   ChevronDownIcon,
@@ -84,37 +85,24 @@ export function FindBar(props: FindBarProps) {
     [editor]
   );
 
-  useEffect(() => {
-    const onKeyDown = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') {
-        e.preventDefault();
-        close();
-        return;
-      }
+  useHotkey('Escape', close);
+  useHotkey('Mod+G', () => step(1));
+  useHotkey('Mod+Shift+G', () => step(-1));
 
-      if (e.key === 'g' && e.metaKey) {
-        e.preventDefault();
-        step(e.shiftKey ? -1 : 1);
-        return;
-      }
+  useHotkey(
+    'Mod+F',
+    () => {
+      inputRef.current?.focus();
+      inputRef.current?.select();
+    },
+    { conflictBehavior: 'allow' }
+  );
 
-      if (e.key === 'f' && e.metaKey) {
-        e.preventDefault();
-        inputRef.current?.focus();
-        inputRef.current?.select();
-      }
-    };
-
-    window.addEventListener('keydown', onKeyDown);
-    return () => window.removeEventListener('keydown', onKeyDown);
-  }, [close, step]);
-
-  const onInputKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
-    if (e.key === 'Enter') {
-      e.preventDefault();
-      step(e.shiftKey ? -1 : 1);
-    }
-  };
+  useHotkey('Enter', () => step(1), { target: inputRef, ignoreInputs: false });
+  useHotkey('Shift+Enter', () => step(-1), {
+    target: inputRef,
+    ignoreInputs: false,
+  });
 
   return (
     <div className="border-border h-9.5 flex shrink-0 items-center gap-1 border-t pr-3">
@@ -134,7 +122,6 @@ export function FindBar(props: FindBarProps) {
             editor.commands.setFindQuery(e.target.value);
             scrollToActiveMatch(editor);
           }}
-          onKeyDown={onInputKeyDown}
         />
       </label>
 

--- a/src-web/src/components/skeleton-editor.tsx
+++ b/src-web/src/components/skeleton-editor.tsx
@@ -42,7 +42,7 @@ export function SkeletonEditor(props: SkeletonEditorProps) {
       scrollMargin: 40,
       attributes: {
         class:
-          'focus:outline-none cursor-text! border-none px-5 pb-0 pt-2 editor-content',
+          'focus:outline-none cursor-text! border-none px-[var(--editor-inset-x)] pb-2 pt-2 editor-content',
       },
     },
     onUpdate: () => {
@@ -143,8 +143,6 @@ export function SkeletonEditor(props: SkeletonEditorProps) {
         onBrowse={browseNotes}
       />
 
-      {isFindOpen && <FindBar editor={editor} onClose={closeFind} />}
-
       <div className="mt-[var(--window-menu-height)] flex h-[calc(100vh-var(--window-menu-height))] flex-col">
         <Divider
           ref={topDividerRef}
@@ -163,7 +161,11 @@ export function SkeletonEditor(props: SkeletonEditorProps) {
           ref={bottomDividerRef}
           className="mt-auto shrink-0 opacity-0 transition-opacity"
         />
-        <MenuBar editor={editor} />
+        {isFindOpen ? (
+          <FindBar editor={editor} onClose={closeFind} />
+        ) : (
+          <MenuBar editor={editor} />
+        )}
       </div>
     </main>
   );

--- a/src-web/src/hooks/use-command-palette.ts
+++ b/src-web/src/hooks/use-command-palette.ts
@@ -22,6 +22,10 @@ export function useCommandPalette(
     actions['new-note']?.();
   });
 
+  useHotkey('Mod+Shift+N', () => {
+    actions['new-note-here']?.();
+  });
+
   useHotkey('Mod+P', () => {
     actions['browse-notes']?.();
   });

--- a/src-web/src/hooks/use-note-actions.ts
+++ b/src-web/src/hooks/use-note-actions.ts
@@ -34,20 +34,31 @@ export function useNoteActions(options: NoteActionsOptions) {
   const navigate = useNavigate();
   const queryClient = useQueryClient();
 
-  const openNewNote = useCallback(async (content: string) => {
-    const newNote = await invoke<Note>('cmd_upsert_note', {
-      note: {
-        model: 'note',
-        content,
-      },
-    });
+  const insertNote = useCallback(
+    async (content: string) => {
+      const newNote = await invoke<Note>('cmd_upsert_note', {
+        note: {
+          model: 'note',
+          content,
+        },
+      });
 
-    queryClient.invalidateQueries(listNotesOptions());
-    await invoke('cmd_new_main_window', {
-      url: `/${newNote.id}`,
-      size: [MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT],
-    });
-  }, []);
+      queryClient.invalidateQueries(listNotesOptions());
+      return newNote;
+    },
+    [queryClient]
+  );
+
+  const openNewNote = useCallback(
+    async (content: string) => {
+      const newNote = await insertNote(content);
+      await invoke('cmd_new_main_window', {
+        url: `/${newNote.id}`,
+        size: [MIN_WINDOW_WIDTH, MIN_WINDOW_HEIGHT],
+      });
+    },
+    [insertNote]
+  );
 
   const createNote = useCallback(async () => {
     if (editor.isEmpty) {
@@ -59,6 +70,27 @@ export function useNoteActions(options: NoteActionsOptions) {
 
     await openNewNote('');
   }, [editor, openNewNote]);
+
+  const createNoteHere = useCallback(async () => {
+    if (editor.isEmpty) {
+      await invoke('cmd_show_toast', {
+        message: 'You already have an empty note',
+      });
+      return;
+    }
+
+    // Unsaved edits must reach disk before the route swaps the editor
+    // out, or they die with it; same as the search-selection handler.
+    await flush();
+
+    const newNote = await insertNote('');
+    navigate({
+      to: '/$noteId',
+      params: {
+        noteId: newNote.id,
+      },
+    });
+  }, [editor, flush, insertNote, navigate]);
 
   const browseNotes = useCallback(async () => {
     await invoke('cmd_open_search_window', {
@@ -97,6 +129,7 @@ export function useNoteActions(options: NoteActionsOptions) {
     }),
     {
       'new-note': createNote,
+      'new-note-here': createNoteHere,
       'duplicate-note': () => openNewNote(editor.getMarkdown()),
       'browse-notes': browseNotes,
       'find-in-note': openFind,

--- a/src-web/src/lib/commands.ts
+++ b/src-web/src/lib/commands.ts
@@ -3,6 +3,7 @@ import {
   ClipboardCopyIcon,
   ClipboardTypeIcon,
   CopyPlusIcon,
+  FilePlusIcon,
   FolderIcon,
   FolderOpenIcon,
   LayersIcon,
@@ -47,6 +48,12 @@ export const commandGroups: CommandGroup[] = [
         label: 'New Note',
         icon: PlusIcon,
         shortcut: ['⌘', 'N'],
+      },
+      {
+        id: 'new-note-here',
+        label: 'New Note in This Window',
+        icon: FilePlusIcon,
+        shortcut: ['⇧', '⌘', 'N'],
       },
       {
         id: 'duplicate-note',

--- a/src-web/src/styles/_editor-content.css
+++ b/src-web/src/styles/_editor-content.css
@@ -183,7 +183,7 @@
   }
 
   a {
-    @apply text-accent cursor-pointer underline;
+    @apply text-accent cursor-pointer break-all underline;
   }
 
   hr {

--- a/src-web/src/styles/_editor-content.css
+++ b/src-web/src/styles/_editor-content.css
@@ -77,6 +77,10 @@
     @apply mb-1.5 text-[15px] leading-snug;
   }
 
+  strong {
+    @apply font-medium;
+  }
+
   ul:not([data-type='taskList']) {
     @apply ps-6.5 mb-2 list-disc;
 

--- a/src-web/src/styles/global.css
+++ b/src-web/src/styles/global.css
@@ -27,6 +27,7 @@
   );
 
   --window-menu-height: 36px;
+  --editor-inset-x: 1.25rem;
 }
 
 html,


### PR DESCRIPTION
## Summary
- Move find-in-note into the footer (replacing the menu bar row while open) so it never overlaps the note's title or top content, and drive its shortcuts (Escape, Mod+G, Enter/Shift+Enter, Mod+F) through `@tanstack/react-hotkeys`.
- Add a shared `--editor-inset-x` variable so the find bar's search icon lines up with the note's text column, and give the editor bottom padding so the last line clears the footer border.
- Smaller editor/window touches: bold text renders at medium weight, long link URLs wrap to fill the line, a "new note in same window" command, shared panel inset/offset constants, and a lighter close-button hover when the window is unfocused.

## Test plan
- [ ] Open find (Mod+F): bar appears in the footer, input autofocuses, title/top content stay put
- [ ] Type a query; Enter / Shift+Enter and Mod+G / Mod+Shift+G step matches; chevrons match
- [ ] Escape closes find and restores the menu bar; no window resize/clipping on open/close
- [ ] Search icon aligns with the note text column; last line has a gap above the footer border
- [ ] Bold text shows medium weight; long URLs wrap; new-note-in-same-window command works